### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -313,6 +313,10 @@
     PDF Tools does not work well together with ~linum-mode~ and
     activating it in a ~pdf-view-mode~, e.g. via ~global-linum-mode~,
     might make Emacs choke.
+    
+*** display-line-numbers-mode
+
+    This mode is an alternative to linum-mode and is available since Emacs 26, but PDF Tools has some problems with it. For example, it makes horizontal navigation (such as C-f, C-b, C-< or C-> ) in a document impossible. 
 
 *** auto-revert
     Autorevert works by polling the file-system every

--- a/README.org
+++ b/README.org
@@ -316,7 +316,7 @@
     
 *** display-line-numbers-mode
 
-    This mode is an alternative to linum-mode and is available since Emacs 26, but PDF Tools has some problems with it. For example, it makes horizontal navigation (such as C-f, C-b, C-< or C-> ) in a document impossible. 
+    This mode is an alternative to linum-mode and is available since Emacs 26, but PDF Tools has some problems with it. For example, it makes horizontal navigation (such as C-f, C-b, C-x < or C-x > ) in a document impossible. 
 
 *** auto-revert
     Autorevert works by polling the file-system every


### PR DESCRIPTION
I found some problems concerning horizontal navigation when I had display-line-numbers-mode active. I could do basic movements such as up or down but when I wanted to scroll left or right the commands C-f, C-b, C-x < and C-x > ( last two remaped as says the help document concerning pdf tools)  did not obey. 